### PR TITLE
feat: Implement OTP login with user creation and token generation

### DIFF
--- a/CoreModule/API/Business/Core/Interface/ILoginService.cs
+++ b/CoreModule/API/Business/Core/Interface/ILoginService.cs
@@ -37,6 +37,6 @@ namespace BusinessLogic.Core.Interface
         /// <summary>
         /// Verifies an OTP provided by a user.
         /// </summary>
-        Task<bool> VerifyOtpAsync(OtpVerifyDto otpVerifyDto);
+        Task<LoginResponseDto> VerifyOtpAsync(OtpVerifyDto otpVerifyDto);
     }
 }

--- a/CoreModule/API/Business/Core/Services/LoginService.cs
+++ b/CoreModule/API/Business/Core/Services/LoginService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using BusinessLogic.Admin.Interface;
 using BusinessLogic.Admin.Services;
@@ -135,30 +136,61 @@ namespace BusinessLogic.Core.Services
 
             if (user == null)
             {
-                // Silently succeed to prevent user enumeration attacks
-                //return true;
-                user =new User { FullName = "New User",Email = otpRequestDto.LoginIdentifier};
+                // Create a dummy user if one doesn't exist
+                var newUser = new User
+                {
+                    UserID = Guid.NewGuid(),
+                    FullName = "New User",
+                    UserHandle = isEmail ? otpRequestDto.LoginIdentifier.Split('@').FirstOrDefault() ?? $"user_{new Random().Next(1000, 9999)}" : otpRequestDto.LoginIdentifier,
+                    Email = isEmail ? otpRequestDto.LoginIdentifier : null,
+                    IsActive = true, // Or false, depending on business logic for new users
+                    CreatedOn = DateTime.UtcNow
+                };
+                user = await _userRepository.AddAsync(newUser);
             }
 
             var otp = new Random().Next(100000, 999999).ToString();
             await _loginRepository.SaveOTPAsync(otpRequestDto.LoginIdentifier, otp);
 
-            if (otpRequestDto.OtpMethod.Equals("email", StringComparison.OrdinalIgnoreCase))
+            if (otpRequestDto.OtpMethod.Equals("email", StringComparison.OrdinalIgnoreCase) && isEmail && !string.IsNullOrEmpty(user.Email))
             {
-                if (isEmail && !string.IsNullOrEmpty(user.Email))
-                {
-                    await _emailService.SendEmail(user.Email, otp, user.FullName);
-                }
+                await _emailService.SendEmail(user.Email, otp, user.FullName);
             }
-
-            // Logic for other OTP methods like SMS can be added here in the future.
 
             return true;
         }
 
-        public async Task<bool> VerifyOtpAsync(OtpVerifyDto otpVerifyDto)
+        public async Task<LoginResponseDto> VerifyOtpAsync(OtpVerifyDto otpVerifyDto)
         {
-            return await _loginRepository.VerifyOTPAsync(otpVerifyDto.LoginIdentifier, otpVerifyDto.Otp);
+            var isValidOtp = await _loginRepository.VerifyOTPAsync(otpVerifyDto.LoginIdentifier, otpVerifyDto.Otp);
+            if (!isValidOtp)
+            {
+                return new LoginResponseDto { IsSuccess = false, Message = "Invalid OTP." };
+            }
+
+            var isEmail = otpVerifyDto.LoginIdentifier.Contains('@');
+            var user = isEmail
+                ? await _userRepository.GetByEmailAsync(otpVerifyDto.LoginIdentifier)
+                : await _userRepository.GetByUserHandleAsync(otpVerifyDto.LoginIdentifier);
+
+            if (user == null)
+            {
+                return new LoginResponseDto { IsSuccess = false, Message = "User not found." };
+            }
+
+            var permissions = await _roleRepository.GetUserPermissionsAcrossBusinessesAsync(user.UserID);
+            var (tokenString, expiration) = _tokenService.GenerateAccessToken(user.UserID.ToString(), user.UserHandle, permissions);
+
+            return new LoginResponseDto
+            {
+                IsSuccess = true,
+                Message = "OTP verified successfully.",
+                Token = tokenString,
+                TokenExpiration = expiration,
+                UserId = user.UserID,
+                UserHandle = user.UserHandle,
+                FullName = user.FullName
+            };
         }
     }
 }

--- a/CoreModule/API/encryptzERP/Controllers/Core/LoginController.cs
+++ b/CoreModule/API/encryptzERP/Controllers/Core/LoginController.cs
@@ -116,16 +116,16 @@ namespace encryptzERP.Controllers.Core
         }
 
         [HttpPost("verify-otp")]
-        public async Task<IActionResult> VerifyOtp(OtpVerifyDto otpVerifyDto)
+        public async Task<ActionResult<LoginResponseDto>> VerifyOtp(OtpVerifyDto otpVerifyDto)
         {
             try
             {
-                var success = await _loginService.VerifyOtpAsync(otpVerifyDto);
-                if (!success)
+                var response = await _loginService.VerifyOtpAsync(otpVerifyDto);
+                if (!response.IsSuccess)
                 {
-                    return BadRequest(new { message = "Invalid OTP." });
+                    return BadRequest(new { message = response.Message });
                 }
-                return Ok(new { message = "OTP verified successfully." });
+                return Ok(response);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This commit modifies the OTP login flow to enhance user experience and functionality.

- The `request-otp` endpoint now creates a new dummy user if the provided identifier (email or phone) does not already exist in the system. This allows new users to register and log in seamlessly via OTP.
- The `verify-otp` endpoint has been updated to return a `LoginResponseDto`, which includes a JWT access token upon successful OTP verification. This enables the user to be authenticated immediately after verifying their OTP.

The `ILoginService` interface and `LoginController` have been updated to support these changes, ensuring consistency across the application layers.